### PR TITLE
Misc fixes

### DIFF
--- a/examples/https-client/src/https-client.py
+++ b/examples/https-client/src/https-client.py
@@ -100,9 +100,9 @@ class HttpsClientCharm(CharmBase):
                 f"/CN={self.unit.name.replace('/', '-')}",
             ]
             try:
-                subprocess.run(cmd, check=True)
+                subprocess.run(cmd, capture_output=True, check=True)
             except subprocess.CalledProcessError as e:
-                self.unit_blocked(f'Failed to run "{e.cmd}": {e.returncode}')
+                self.unit_blocked(f'Failed to run "{e.cmd}": {e.stderr} ({e.returncode})')
                 return
 
             # Save the self-signed certificate for later use


### PR DESCRIPTION
If the "https" relation is not usable due to not having any `core.https_address` listener on the LXD side, abort early in the relation-changed hook. This avoid giving false expectations to relating units.