### PR TITLE
lxd: default to ceph builtin tools/configs

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -36,6 +36,7 @@ options:
   snap-config-ceph-builtin:
     type: boolean
     description: Use snap-specific ceph configuration
+    default: true
   snap-config-ceph-external:
     type: boolean
     description: Use the system's ceph tools (ignores snap-config-ceph-builtin)


### PR DESCRIPTION
Signed-off-by: Simon Deziel <simon.deziel@canonical.com>