### PR TITLE
Highlight that the "ceph" interface is optional

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -53,3 +53,4 @@ provides:
 requires:
   ceph:
     interface: ceph-client
+    optional: true


### PR DESCRIPTION
Juju uses the "requires" keyword for relations it consumes.
This keyword is confusing so an "optional" keyword (ignored by Juju)
was added to communicate the optionality to administrators.

Signed-off-by: Simon Deziel <simon.deziel@canonical.com>