### PR TITLE
Remove unneeded passenv from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,11 +19,7 @@ passenv =
     PYTHONPATH
     HOME
     PATH
-    CHARM_BUILD_DIR
     MODEL_SETTINGS
-    HTTP_PROXY
-    HTTPS_PROXY
-    NO_PROXY
 deps =
     -rrequirements-dev.txt
 


### PR DESCRIPTION
Signed-off-by: Simon Deziel <simon.deziel@canonical.com>