### PR TITLE
Stop tweaking net.core.bpf_jit_limit as kernel 5.15 have sane default

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -43,7 +43,6 @@ SYSCTL_CONFIGS = {
     "kernel.dmesg_restrict": 1,
     "kernel.keys.maxbytes": 2000000,
     "kernel.keys.maxkeys": 2000,
-    "net.core.bpf_jit_limit": 3000000000,
     "net.ipv4.neigh.default.gc_thresh3": 8192,
     "net.ipv6.neigh.default.gc_thresh3": 8192,
     "vm.max_map_count": 262144,


### PR DESCRIPTION
Signed-off-by: Simon Deziel <simon.deziel@canonical.com>