### PR TITLE
Add support for `core.dns_address`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,15 +79,17 @@ jobs:
     - name: Test opening/closing ports
       run: |
         set -eux
-        # open the bgp and metrics ports
-        juju config lxd lxd-listen-bgp=true lxd-listen-metrics=true
+        # open the dns, bgp and metrics ports
+        juju config lxd lxd-listen-dns=true lxd-listen-bgp=true lxd-listen-metrics=true
         juju wait
-        # check that the bgp, https and metrics ports are opened
-        OPENED_PORTS="$(juju run --unit lxd/leader "opened-ports" | grep -cE '^(179|8443|9100)/tcp$')"
-        [ "$OPENED_PORTS" -eq 3 ]
-        # close the bgp and metrics ports
-        juju config lxd lxd-listen-bgp=false lxd-listen-metrics=false
+        juju status
+        # check that the dns, bgp, https and metrics ports are opened
+        OPENED_PORTS="$(juju run --unit lxd/leader "opened-ports" | grep -cE '^(53|179|8443|9100)/tcp$')"
+        [ "$OPENED_PORTS" -eq 4 ]
+        # close the dns, bgp and metrics ports
+        juju config lxd lxd-listen-dns=false lxd-listen-bgp=false lxd-listen-metrics=false
         juju wait
+        juju status
         # check that only the https port remains opened
         HTTPS_PORT="$(juju run --unit lxd/leader "opened-ports" | grep -E '^[0-9]+/tcp$')"
         [ "$HTTPS_PORT" = "8443/tcp" ]

--- a/config.yaml
+++ b/config.yaml
@@ -9,6 +9,11 @@ options:
     default: false
     description: Enable/disable the BGP endpoint
 
+  lxd-listen-dns:
+    type: boolean
+    default: false
+    description: Enable/disable the authoritative DNS endpoint
+
   lxd-listen-https:
     type: boolean
     default: false

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -45,6 +45,8 @@ peers:
 provides:
   bgp:
     interface: lxd-bgp
+  dns:
+    interface: lxd-dns
   grafana-dashboard:
     interface: grafana-dashboard
   https:

--- a/src/charm.py
+++ b/src/charm.py
@@ -214,7 +214,7 @@ class LxdCharm(CharmBase):
 
         # Space binding changes will trigger this event but won't show up in self.config
         # so those need to be processed even when config_changed() returns nothing
-        for listener in ("bgp", "https", "metrics"):
+        for listener in ("bgp", "dns", "https", "metrics"):
             # Check if we should listen
             toggle_key = f"lxd-listen-{listener}"
             toggle_value = self.config.get(toggle_key)
@@ -1658,6 +1658,7 @@ class LxdCharm(CharmBase):
         # default ports
         ports = {
             "bgp": 179,
+            "dns": 53,
             "https": 8443,
             "metrics": 9100,
         }
@@ -1668,6 +1669,7 @@ class LxdCharm(CharmBase):
         # Some listeners require a special API extension
         api_extensions = {
             "bgp": "network_bgp",
+            "dns": "network_dns",
             "metrics": "metrics",
         }
 


### PR DESCRIPTION
Fixes #66.

I initially wanted to add `lxd-listen-dns` to tests but this fails due to LXD failing to bind port 53 that's already taken by systemd-resolved. A possible solution would be to reconfigure systemd-resolved to disable the stub listeners but I didn't feel it was worth it.