### PR TITLE
bundles: prometheus2 stable channel now has what we need

### DIFF
--- a/bundles/all-in-one.yaml
+++ b/bundles/all-in-one.yaml
@@ -62,8 +62,7 @@ applications:
       totally-unsecure-auto-unlock: true
   prometheus2:
     charm: prometheus2
-    # requires revision 28 or later hence edge and focal
-    channel: edge
+    channel: stable
     series: focal
     num_units: 1
     to:

--- a/bundles/lxd-and-prometheus2+grafana.yaml
+++ b/bundles/lxd-and-prometheus2+grafana.yaml
@@ -32,7 +32,6 @@ applications:
     charm: lxd
     options:
       lxd-listen-https: true
-      snap-channel: latest/edge
       mode: cluster
     num_units: 3
     to:

--- a/bundles/lxd-and-prometheus2+grafana.yaml
+++ b/bundles/lxd-and-prometheus2+grafana.yaml
@@ -18,8 +18,7 @@ machines:
 applications:
   prometheus2:
     charm: prometheus2
-    # requires revision 28 or later hence edge and focal
-    channel: edge
+    channel: stable
     series: focal
     num_units: 1
     to:


### PR DESCRIPTION
While at it, fix the LXD and prometheus2+grafana bundle to not pull LXD from `latest/edge`.