### PR TITLE
ci: only run integration tests if static analysis passed

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -24,7 +24,7 @@ jobs:
           sudo -g lxd charmcraft pack
 
     - name: Upload charm
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: lxd_ubuntu-20.04-amd64.charm
         path: lxd_ubuntu-20.04-amd64.charm

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,8 @@ jobs:
   integration-tests:
     name: Juju tests
     runs-on: ubuntu-20.04
+    needs:
+    - static-analysis
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -184,7 +184,7 @@ jobs:
 
     - name: Juju debug-log
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: juju-debug-logs ${{ github.job }}
         path: juju-debug.log


### PR DESCRIPTION
Update actions/upload-artifact while at it.