### PR TITLE
Fix charm installation by using a fresh pyopenssl version

### DIFF
--- a/examples/https-client/requirements.txt
+++ b/examples/https-client/requirements.txt
@@ -1,2 +1,3 @@
-git+https://github.com/lxc/pylxd@master#egg=pylxd
 ops >= 1.2.0
+git+https://github.com/lxc/pylxd@master#egg=pylxd
+pyopenssl

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ops >= 1.2.0
 git+https://github.com/lxc/pylxd@master#egg=pylxd
+pyopenssl
 pyyaml


### PR DESCRIPTION
This ensures the OS provided python3-openssl package won't be used as it conflicts with a newer cryptography module that is installed through pip. See https://github.com/pyca/pyopenssl/issues/1143 for details.