### PR TITLE
Misc fixes

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -786,9 +786,6 @@ class LxdCharm(CharmBase):
             return
 
         cluster_member_config: List[Dict] = self.get_peer_data_list(self.app, "member_config")
-        if not cluster_member_config:
-            logger.error(f"Missing member_config in {self.app.name}")
-            return
 
         # Use the token and member_config to join the cluster
         logger.debug(f"Cluster joining information found in {self.app.name}")


### PR DESCRIPTION
Fix cluster join when `lxd-init-network` and `lxd-init-storage` are both `false` which caused the `member_config` would be empty and empty lists are not saved in Juju data bags. In Juju, saving a key with an empty value deletes the key.

Also, improve the HTTPS relation interface to provide the address of each of the cluster members. Problem reported by @masnax.