### PR TITLE
Use `cosl` instead of deprecated `observability_libs.v0.juju_topology`

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -2,6 +2,9 @@ name: Commits
 on:
   - pull_request
 
+permissions:
+  contents: read
+
 jobs:
   cla-check:
     name: Canonical CLA signed

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,9 @@ on:
   - push
   - pull_request
 
+permissions:
+  contents: read
+
 jobs:
   static-analysis:
     name: Static analysis

--- a/examples/https-client/src/https-client.py
+++ b/examples/https-client/src/https-client.py
@@ -4,6 +4,7 @@
 
 import logging
 import subprocess
+from pathlib import Path
 
 import pylxd
 from ops.charm import (
@@ -36,7 +37,6 @@ class HttpsClientCharm(CharmBase):
 
         # Initialize the persistent storage if needed
         self._stored.set_default(
-            cert="",
             remote_lxd_is_clustered="false",
         )
 
@@ -50,12 +50,49 @@ class HttpsClientCharm(CharmBase):
         self.framework.observe(self.on.https_relation_changed, self._on_https_relation_changed)
         self.framework.observe(self.on.https_relation_created, self._on_https_relation_created)
 
+    def generate_cert(self) -> None:
+        """Generate a self-signed certificate for the client."""
+        cmd = [
+            "openssl",
+            "req",
+            "-x509",
+            "-newkey",
+            "ec",
+            "-pkeyopt",
+            "ec_paramgen_curve:secp384r1",
+            "-sha384",
+            "-keyout",
+            "client.key",
+            "-out",
+            "client.crt",
+            "-nodes",
+            "-subj",
+            f"/CN={self.unit.name.replace('/', '-')}",
+            "-days",
+            "3650",
+        ]
+        try:
+            subprocess.run(cmd, capture_output=True, check=True)
+        except subprocess.CalledProcessError as e:
+            self.unit_blocked(f'Failed to run "{e.cmd}": {e.stderr} ({e.returncode})')
+            return
+
+    @property
+    def cert(self) -> str:
+        """Return the client certificate."""
+        try:
+            cert: str = Path("client.crt").read_text()
+        except FileNotFoundError:
+            return ""
+
+        return cert
+
     def config_to_databag(self) -> dict:
         """Translate config data to be storable in a data bag."""
         # Prepare data to be sent (only strings, no bool nor None)
         d = {
             "version": "1.0",
-            "certificate": self._stored.cert,
+            "certificate": self.cert,
         }
 
         projects: str = self.config.get("projects", "")
@@ -82,42 +119,15 @@ class HttpsClientCharm(CharmBase):
 
     def _on_charm_install(self, event: InstallEvent) -> None:
         """Generate a self-signed cert if needed."""
-        if self._stored.cert != "":
+        if self.cert:
             return
 
         self.unit_maintenance("Generating a self-signed cert")
-        cmd = [
-            "openssl",
-            "req",
-            "-x509",
-            "-newkey",
-            "ec",
-            "-pkeyopt",
-            "ec_paramgen_curve:secp384r1",
-            "-sha384",
-            "-keyout",
-            "client.key",
-            "-out",
-            "client.crt",
-            "-nodes",
-            "-subj",
-            f"/CN={self.unit.name.replace('/', '-')}",
-            "-days",
-            "3650",
-        ]
-        try:
-            subprocess.run(cmd, capture_output=True, check=True)
-        except subprocess.CalledProcessError as e:
-            self.unit_blocked(f'Failed to run "{e.cmd}": {e.stderr} ({e.returncode})')
-            return
-
-        # Save the self-signed certificate for later use
-        with open("client.crt") as f:
-            self._stored.cert = f.read()
+        self.generate_cert()
 
     def _on_charm_start(self, event: StartEvent) -> None:
         """Start the unit if a cert was properly generated on install."""
-        if self._stored.cert == "":
+        if not self.cert:
             self.unit_blocked("no cert available")
             return
 
@@ -223,7 +233,7 @@ class HttpsClientCharm(CharmBase):
 
     def _on_https_relation_created(self, event: RelationCreatedEvent) -> None:
         """Upload our client certificate to the remote unit."""
-        if self._stored.cert == "":
+        if not self.cert:
             logger.error("no cert available")
             return
 

--- a/examples/https-client/src/https-client.py
+++ b/examples/https-client/src/https-client.py
@@ -36,7 +36,7 @@ class HttpsClientCharm(CharmBase):
 
         # Initialize the persistent storage if needed
         self._stored.set_default(
-            cert=None,
+            cert="",
             remote_lxd_is_clustered=False,
         )
 
@@ -81,42 +81,47 @@ class HttpsClientCharm(CharmBase):
             https_relation.data[self.unit].update(self.config_to_databag())
 
     def _on_charm_install(self, event: InstallEvent) -> None:
-        """Generate a self-signed cert."""
-        if not self._stored.cert:
-            self.unit_maintenance("Generating a self-signed cert")
-            cmd = [
-                "openssl",
-                "req",
-                "-x509",
-                "-newkey",
-                "ec",
-                "-pkeyopt",
-                "ec_paramgen_curve:secp384r1",
-                "-sha384",
-                "-keyout",
-                "client.key",
-                "-out",
-                "client.crt",
-                "-nodes",
-                "-subj",
-                f"/CN={self.unit.name.replace('/', '-')}",
-                "-days",
-                "3650",
-            ]
-            try:
-                subprocess.run(cmd, capture_output=True, check=True)
-            except subprocess.CalledProcessError as e:
-                self.unit_blocked(f'Failed to run "{e.cmd}": {e.stderr} ({e.returncode})')
-                return
+        """Generate a self-signed cert if needed."""
+        if self._stored.cert != "":
+            return
 
-            # Save the self-signed certificate for later use
-            with open("client.crt") as f:
-                self._stored.cert = f.read()
+        self.unit_maintenance("Generating a self-signed cert")
+        cmd = [
+            "openssl",
+            "req",
+            "-x509",
+            "-newkey",
+            "ec",
+            "-pkeyopt",
+            "ec_paramgen_curve:secp384r1",
+            "-sha384",
+            "-keyout",
+            "client.key",
+            "-out",
+            "client.crt",
+            "-nodes",
+            "-subj",
+            f"/CN={self.unit.name.replace('/', '-')}",
+            "-days",
+            "3650",
+        ]
+        try:
+            subprocess.run(cmd, capture_output=True, check=True)
+        except subprocess.CalledProcessError as e:
+            self.unit_blocked(f'Failed to run "{e.cmd}": {e.stderr} ({e.returncode})')
+            return
+
+        # Save the self-signed certificate for later use
+        with open("client.crt") as f:
+            self._stored.cert = f.read()
 
     def _on_charm_start(self, event: StartEvent) -> None:
         """Start the unit if a cert was properly generated on install."""
-        if self._stored.cert:
-            self.unit_active("Starting the https-client charm")
+        if self._stored.cert == "":
+            self.unit_blocked("no cert available")
+            return
+
+        self.unit_active("Starting the https-client charm")
 
     def _on_https_relation_broken(self, event: RelationBrokenEvent) -> None:
         """Forget that we previously dealt with a remote LXD cluster."""
@@ -212,7 +217,7 @@ class HttpsClientCharm(CharmBase):
 
     def _on_https_relation_created(self, event: RelationCreatedEvent) -> None:
         """Upload our client certificate to the remote unit."""
-        if not self._stored.cert:
+        if self._stored.cert == "":
             logger.error("no cert available")
             return
 

--- a/examples/https-client/src/https-client.py
+++ b/examples/https-client/src/https-client.py
@@ -16,7 +16,6 @@ from ops.charm import (
     RelationCreatedEvent,
     StartEvent,
 )
-from ops.framework import StoredState
 from ops.main import main
 from ops.model import ActiveStatus, Application, BlockedStatus, MaintenanceStatus, Unit
 
@@ -29,16 +28,9 @@ logging.getLogger("urllib3").setLevel(logging.WARNING)
 class HttpsClientCharm(CharmBase):
     """https-client charm class."""
 
-    _stored = StoredState()
-
     def __init__(self, *args):
         """Initialize charm's variables."""
         super().__init__(*args)
-
-        # Initialize the persistent storage if needed
-        self._stored.set_default(
-            remote_lxd_is_clustered="false",
-        )
 
         # Main event handlers
         self.framework.observe(self.on.config_changed, self._on_charm_config_changed)
@@ -86,6 +78,11 @@ class HttpsClientCharm(CharmBase):
             return ""
 
         return cert
+
+    @property
+    def remote_lxd_is_clustered(self) -> bool:
+        """Return True if the remote LXD is clustered, False otherwise."""
+        return Path("cluster.crt").exists()
 
     def config_to_databag(self) -> dict:
         """Translate config data to be storable in a data bag."""
@@ -135,8 +132,8 @@ class HttpsClientCharm(CharmBase):
 
     def _on_https_relation_broken(self, event: RelationBrokenEvent) -> None:
         """Forget that we previously dealt with a remote LXD cluster."""
-        if self._stored.remote_lxd_is_clustered == "true":
-            self._stored.remote_lxd_is_clustered = "false"
+        if self.remote_lxd_is_clustered:
+            Path("cluster.crt").unlink()
             logger.debug("Forgetting our previous relation with a remote LXD cluster")
 
     def _on_https_relation_changed(self, event: RelationChangedEvent) -> None:
@@ -148,7 +145,7 @@ class HttpsClientCharm(CharmBase):
         """
         # If we are dealing with a clustered LXD, only check connectivity
         # once for the whole cluster, not individual units
-        if self._stored.remote_lxd_is_clustered == "true":
+        if self.remote_lxd_is_clustered:
             if event.unit:
                 remote_unit = event.unit.name
             else:
@@ -156,19 +153,20 @@ class HttpsClientCharm(CharmBase):
             logger.debug(f"{remote_unit} is part of a known cluster, nothing to do")
             return
 
+        version: str = ""
+        remote_crt: str = "server.crt"
+
         for bag in (event.app, event.unit):
             if not bag:
                 continue
 
             d = event.relation.data[bag]
-            version = d.get("version")
+            version = d.get("version", "")
             if version:
                 # If the app data bag is where we found the version it
                 # means we are dealing with a LXD cluster at the other end
                 if bag == event.app:
-                    self._stored.remote_lxd_is_clustered = "true"
-                else:
-                    self._stored.remote_lxd_is_clustered = "false"
+                    remote_crt = "cluster.crt"
                 break
             else:
                 logger.debug(f"No version found in {bag.name}")
@@ -184,8 +182,8 @@ class HttpsClientCharm(CharmBase):
             logger.error(f"Incompatible version ({version}) found in {bag.name}")
             return
 
-        certificate = d.get("certificate")
-        certificate_fingerprint = d.get("certificate_fingerprint")
+        certificate: str = d.get("certificate", "")
+        certificate_fingerprint: str = d.get("certificate_fingerprint", "")
         addresses = d.get("addresses", [])
 
         # Convert string to list
@@ -212,20 +210,20 @@ class HttpsClientCharm(CharmBase):
             return
 
         # pylxd needs a CA cert on disk for verification
-        with open("server.crt", "w") as f:
+        with open(remote_crt, "w") as f:
             f.write(certificate)
 
         # Connect to the remote lxd unit
         client = pylxd.Client(
             endpoint=f"https://{addresses[0]}",
             cert=("client.crt", "client.key"),
-            verify="server.crt",
+            verify=remote_crt,
         )
 
         # Report remote LXD version to show the connection worked
         server_version = client.host_info["environment"]["server_version"]
 
-        if self._stored.remote_lxd_is_clustered == "true":
+        if remote_crt == "cluster.crt":
             msg = f"The cluster runs LXD version: {server_version}"
         else:
             msg = f"{bag.name} runs LXD version: {server_version}"

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -219,7 +219,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 28
+LIBPATCH = 35
 
 logger = logging.getLogger(__name__)
 
@@ -525,7 +525,7 @@ def _validate_relation_by_interface_and_direction(
     relation = charm.meta.relations[relation_name]
 
     actual_relation_interface = relation.interface_name
-    if actual_relation_interface != expected_relation_interface:
+    if actual_relation_interface and actual_relation_interface != expected_relation_interface:
         raise RelationInterfaceMismatchError(
             relation_name, expected_relation_interface, actual_relation_interface
         )
@@ -582,7 +582,7 @@ def _convert_dashboard_fields(content: str, inject_dropdowns: bool = True) -> st
 
     # If no existing template variables exist, just insert our own
     if "templating" not in dict_content:
-        dict_content["templating"] = {"list": [d for d in template_dropdowns]}  # type: ignore
+        dict_content["templating"] = {"list": list(template_dropdowns)}  # type: ignore
     else:
         # Otherwise, set a flag so we can go back later
         existing_templates = True
@@ -665,14 +665,14 @@ def _template_panels(
             continue
         if not existing_templates:
             datasource = panel.get("datasource")
-            if type(datasource) == str:
+            if isinstance(datasource, str):
                 if "loki" in datasource:
                     panel["datasource"] = "${lokids}"
                 elif "grafana" in datasource:
                     continue
                 else:
                     panel["datasource"] = "${prometheusds}"
-            elif type(datasource) == dict:
+            elif isinstance(datasource, dict):
                 # In dashboards exported by Grafana 9, datasource type is dict
                 dstype = datasource.get("type", "")
                 if dstype == "loki":
@@ -686,7 +686,7 @@ def _template_panels(
                 logger.error("Unknown datasource format: skipping")
                 continue
         else:
-            if type(panel["datasource"]) == str:
+            if isinstance(panel["datasource"], str):
                 if panel["datasource"].lower() in replacements.values():
                     # Already a known template variable
                     continue
@@ -701,7 +701,7 @@ def _template_panels(
                 if replacement:
                     used_replacements.append(ds)
                 panel["datasource"] = replacement or panel["datasource"]
-            elif type(panel["datasource"]) == dict:
+            elif isinstance(panel["datasource"], dict):
                 dstype = panel["datasource"].get("type", "")
                 if panel["datasource"].get("uid", "").lower() in replacements.values():
                     # Already a known template variable
@@ -790,7 +790,7 @@ def _inject_labels(content: str, topology: dict, transformer: "CosTool") -> str:
 
     # We need to use an index so we can insert the changed element back later
     for panel_idx, panel in enumerate(panels):
-        if type(panel) is not dict:
+        if not isinstance(panel, dict):
             continue
 
         # Use the index to insert it back in the same location
@@ -830,18 +830,18 @@ def _modify_panel(panel: dict, topology: dict, transformer: "CosTool") -> dict:
 
         if "datasource" not in panel.keys():
             continue
-        else:
-            if type(panel["datasource"]) == str:
-                if panel["datasource"] not in known_datasources:
-                    continue
-                querytype = known_datasources[panel["datasource"]]
-            elif type(panel["datasource"]) == dict:
-                if panel["datasource"]["uid"] not in known_datasources:
-                    continue
-                querytype = known_datasources[panel["datasource"]["uid"]]
-            else:
-                logger.error("Unknown datasource format: skipping")
+
+        if isinstance(panel["datasource"], str):
+            if panel["datasource"] not in known_datasources:
                 continue
+            querytype = known_datasources[panel["datasource"]]
+        elif isinstance(panel["datasource"], dict):
+            if panel["datasource"]["uid"] not in known_datasources:
+                continue
+            querytype = known_datasources[panel["datasource"]["uid"]]
+        else:
+            logger.error("Unknown datasource format: skipping")
+            continue
 
         # Capture all values inside `[]` into a list which we'll iterate over later to
         # put them back in-order. Then apply the regex again and replace everything with
@@ -901,13 +901,12 @@ def _type_convert_stored(obj):
     """Convert Stored* to their appropriate types, recursively."""
     if isinstance(obj, StoredList):
         return list(map(_type_convert_stored, obj))
-    elif isinstance(obj, StoredDict):
+    if isinstance(obj, StoredDict):
         rdict = {}  # type: Dict[Any, Any]
         for k in obj.keys():
             rdict[k] = _type_convert_stored(obj[k])
         return rdict
-    else:
-        return obj
+    return obj
 
 
 class GrafanaDashboardsChanged(EventBase):
@@ -956,7 +955,7 @@ class GrafanaDashboardEvent(EventBase):
         """Restore grafana source information."""
         self.error_message = snapshot["error_message"]
         self.valid = snapshot["valid"]
-        self.errors = json.loads(snapshot["errors"])
+        self.errors = json.loads(str(snapshot["errors"]))
 
 
 class GrafanaProviderEvents(ObjectEvents):
@@ -969,7 +968,7 @@ class GrafanaDashboardProvider(Object):
     """An API to provide Grafana dashboards to a Grafana charm."""
 
     _stored = StoredState()
-    on = GrafanaProviderEvents()
+    on = GrafanaProviderEvents()  # pyright: ignore
 
     def __init__(
         self,
@@ -1073,7 +1072,7 @@ class GrafanaDashboardProvider(Object):
         """
         # Update of storage must be done irrespective of leadership, so
         # that the stored state is there when this unit becomes leader.
-        stored_dashboard_templates = self._stored.dashboard_templates  # type: Any
+        stored_dashboard_templates: Any = self._stored.dashboard_templates  # pyright: ignore
 
         encoded_dashboard = _encode_dashboard_content(content)
 
@@ -1094,7 +1093,7 @@ class GrafanaDashboardProvider(Object):
         """Remove all dashboards to the relation added via :method:`add_dashboard`."""
         # Update of storage must be done irrespective of leadership, so
         # that the stored state is there when this unit becomes leader.
-        stored_dashboard_templates = self._stored.dashboard_templates  # type: Any
+        stored_dashboard_templates: Any = self._stored.dashboard_templates  # pyright: ignore
 
         for dashboard_id in list(stored_dashboard_templates.keys()):
             if dashboard_id.startswith("prog:"):
@@ -1121,7 +1120,7 @@ class GrafanaDashboardProvider(Object):
         # Ensure we do not leave outdated dashboards by removing from stored all
         # the encoded dashboards that start with "file/".
         if self._dashboards_path:
-            stored_dashboard_templates = self._stored.dashboard_templates  # type: Any
+            stored_dashboard_templates: Any = self._stored.dashboard_templates  # pyright: ignore
 
             for dashboard_id in list(stored_dashboard_templates.keys()):
                 if dashboard_id.startswith("file:"):
@@ -1175,7 +1174,7 @@ class GrafanaDashboardProvider(Object):
                 e.grafana_dashboards_absolute_path,
                 e.message,
             )
-            stored_dashboard_templates = self._stored.dashboard_templates  # type: Any
+            stored_dashboard_templates: Any = self._stored.dashboard_templates  # pyright: ignore
 
             for dashboard_id in list(stored_dashboard_templates.keys()):
                 if dashboard_id.startswith("file:"):
@@ -1196,6 +1195,7 @@ class GrafanaDashboardProvider(Object):
                 `grafana_dashboaard` relationship is joined
         """
         if self._charm.unit.is_leader():
+            self._update_all_dashboards_from_dir()
             self._upset_dashboards_on_relation(event.relation)
 
     def _on_grafana_dashboard_relation_changed(self, event: RelationChangedEvent) -> None:
@@ -1213,16 +1213,18 @@ class GrafanaDashboardProvider(Object):
             valid = bool(data.get("valid", True))
             errors = data.get("errors", [])
             if valid and not errors:
-                self.on.dashboard_status_changed.emit(valid=valid)
+                self.on.dashboard_status_changed.emit(valid=valid)  # pyright: ignore
             else:
-                self.on.dashboard_status_changed.emit(valid=valid, errors=errors)
+                self.on.dashboard_status_changed.emit(  # pyright: ignore
+                    valid=valid, errors=errors
+                )
 
     def _upset_dashboards_on_relation(self, relation: Relation) -> None:
         """Update the dashboards in the relation data bucket."""
         # It's completely ridiculous to add a UUID, but if we don't have some
         # pseudo-random value, this never makes it across 'juju set-state'
         stored_data = {
-            "templates": _type_convert_stored(self._stored.dashboard_templates),
+            "templates": _type_convert_stored(self._stored.dashboard_templates),  # pyright: ignore
             "uuid": str(uuid.uuid4()),
         }
 
@@ -1251,13 +1253,13 @@ class GrafanaDashboardProvider(Object):
     @property
     def dashboard_templates(self) -> List:
         """Return a list of the known dashboard templates."""
-        return [v for v in self._stored.dashboard_templates.values()]  # type: ignore
+        return list(self._stored.dashboard_templates.values())  # type: ignore
 
 
 class GrafanaDashboardConsumer(Object):
     """A consumer object for working with Grafana Dashboards."""
 
-    on = GrafanaDashboardEvents()
+    on = GrafanaDashboardEvents()  # pyright: ignore
     _stored = StoredState()
 
     def __init__(
@@ -1305,7 +1307,7 @@ class GrafanaDashboardConsumer(Object):
         self._relation_name = relation_name
         self._tranformer = CosTool(self._charm)
 
-        self._stored.set_default(dashboards=dict())  # type: ignore
+        self._stored.set_default(dashboards={})  # type: ignore
 
         self.framework.observe(
             self._charm.on[self._relation_name].relation_changed,
@@ -1349,13 +1351,13 @@ class GrafanaDashboardConsumer(Object):
             changes = self._render_dashboards_and_signal_changed(event.relation)
 
         if changes:
-            self.on.dashboards_changed.emit()
+            self.on.dashboards_changed.emit()  # pyright: ignore
 
     def _on_grafana_peer_changed(self, _: RelationChangedEvent) -> None:
         """Emit dashboard events on peer events so secondary charm data updates."""
         if self._charm.unit.is_leader():
             return
-        self.on.dashboards_changed.emit()
+        self.on.dashboards_changed.emit()  # pyright: ignore
 
     def update_dashboards(self, relation: Optional[Relation] = None) -> None:
         """Re-establish dashboards on one or more relations.
@@ -1402,7 +1404,7 @@ class GrafanaDashboardConsumer(Object):
         """
         other_app = relation.app
 
-        raw_data = relation.data[other_app].get("dashboards", {})  # type: ignore
+        raw_data = relation.data[other_app].get("dashboards", "")  # pyright: ignore
 
         if not raw_data:
             logger.warning(
@@ -1417,11 +1419,6 @@ class GrafanaDashboardConsumer(Object):
         # The only piece of data needed on this side of the relations is "templates"
         templates = data.pop("templates")
 
-        # Import only if a charmed operator uses the consumer, we don't impose these
-        # dependencies on the client
-        from jinja2 import Template
-        from jinja2.exceptions import TemplateSyntaxError
-
         # The dashboards are WAY too big since this ultimately calls out to Juju to
         # set the relation data, and it overflows the maximum argument length for
         # subprocess, so we have to use b64, annoyingly.
@@ -1434,14 +1431,12 @@ class GrafanaDashboardConsumer(Object):
         relation_has_invalid_dashboards = False
 
         for _, (fname, template) in enumerate(templates.items()):
-            decoded_content = None
             content = None
             error = None
             topology = template.get("juju_topology", {})
             try:
-                decoded_content = _decode_dashboard_content(template["content"])
+                content = _decode_dashboard_content(template["content"])
                 inject_dropdowns = template.get("inject_dropdowns", True)
-                content = Template(decoded_content).render()
                 content = self._manage_dashboard_uid(content, template)
                 content = _convert_dashboard_fields(content, inject_dropdowns)
 
@@ -1456,9 +1451,6 @@ class GrafanaDashboardConsumer(Object):
                 error = str(e.msg)
                 logger.warning("Invalid JSON in Grafana dashboard: {}".format(fname))
                 continue
-            except TemplateSyntaxError as e:
-                error = str(e)
-                relation_has_invalid_dashboards = True
 
             # Prepend the relation name and ID to the dashboard ID to avoid clashes with
             # multiple relations with apps from the same charm, or having dashboards with
@@ -1505,28 +1497,27 @@ class GrafanaDashboardConsumer(Object):
 
             # Dropping dashboards for a relation needs to be signalled
             return True
-        else:
-            stored_data = rendered_dashboards
-            currently_stored_data = self._get_stored_dashboards(relation.id)
 
-            coerced_data = (
-                _type_convert_stored(currently_stored_data) if currently_stored_data else {}
-            )
+        stored_data = rendered_dashboards
+        currently_stored_data = self._get_stored_dashboards(relation.id)
 
-            if not coerced_data == stored_data:
-                stored_dashboards = self.get_peer_data("dashboards")
-                stored_dashboards[relation.id] = stored_data
-                self.set_peer_data("dashboards", stored_dashboards)
-                return True
+        coerced_data = _type_convert_stored(currently_stored_data) if currently_stored_data else {}
+
+        if not coerced_data == stored_data:
+            stored_dashboards = self.get_peer_data("dashboards")
+            stored_dashboards[relation.id] = stored_data
+            self.set_peer_data("dashboards", stored_dashboards)
+            return True
+        return None  # type: ignore
 
     def _manage_dashboard_uid(self, dashboard: str, template: dict) -> str:
         """Add an uid to the dashboard if it is not present."""
-        dashboard = json.loads(dashboard)
+        dashboard_dict = json.loads(dashboard)
 
-        if not dashboard.get("uid", None) and "dashboard_alt_uid" in template:
-            dashboard["uid"] = template["dashboard_alt_uid"]
+        if not dashboard_dict.get("uid", None) and "dashboard_alt_uid" in template:
+            dashboard_dict["uid"] = template["dashboard_alt_uid"]
 
-        return json.dumps(dashboard)
+        return json.dumps(dashboard_dict)
 
     def _remove_all_dashboards_for_relation(self, relation: Relation) -> None:
         """If an errored dashboard is in stored data, remove it and trigger a deletion."""
@@ -1534,7 +1525,7 @@ class GrafanaDashboardConsumer(Object):
             stored_dashboards = self.get_peer_data("dashboards")
             stored_dashboards.pop(str(relation.id))
             self.set_peer_data("dashboards", stored_dashboards)
-            self.on.dashboards_changed.emit()
+            self.on.dashboards_changed.emit()  # pyright: ignore
 
     def _to_external_object(self, relation_id, dashboard):
         return {
@@ -1616,7 +1607,7 @@ class GrafanaDashboardAggregator(Object):
     """
 
     _stored = StoredState()
-    on = GrafanaProviderEvents()
+    on = GrafanaProviderEvents()  # pyright: ignore
 
     def __init__(
         self,
@@ -1681,7 +1672,7 @@ class GrafanaDashboardAggregator(Object):
         """Push dashboards to the downstream Grafana relation."""
         # It's still ridiculous to add a UUID here, but needed
         stored_data = {
-            "templates": _type_convert_stored(self._stored.dashboard_templates),
+            "templates": _type_convert_stored(self._stored.dashboard_templates),  # pyright: ignore
             "uuid": str(uuid.uuid4()),
         }
 
@@ -1702,7 +1693,7 @@ class GrafanaDashboardAggregator(Object):
             del self._stored.dashboard_templates[id]  # type: ignore
 
         stored_data = {
-            "templates": _type_convert_stored(self._stored.dashboard_templates),
+            "templates": _type_convert_stored(self._stored.dashboard_templates),  # pyright: ignore
             "uuid": str(uuid.uuid4()),
         }
 
@@ -1830,10 +1821,10 @@ class GrafanaDashboardAggregator(Object):
             # Replace old piechart panels
             dash = re.sub(r'"type": "grafana-piechart-panel"', '"type": "piechart"', dash)
 
-            from jinja2 import Template
+            from jinja2 import DebugUndefined, Template
 
             content = _encode_dashboard_content(
-                Template(dash).render(host=r"$host", datasource=r"${prometheusds}")  # type: ignore
+                Template(dash, undefined=DebugUndefined).render(datasource=r"${prometheusds}")  # type: ignore
             )
             id = "prog:{}".format(content[-24:-16])
 

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -32,7 +32,7 @@ logs on the fly.
 This object may be used by any Charmed Operator which implements the `loki_push_api` interface.
 For instance, Loki or Grafana Agent.
 
-For this purposes a charm needs to instantiate the `LokiPushApiProvider` object with one mandatory
+For this purpose a charm needs to instantiate the `LokiPushApiProvider` object with one mandatory
 and three optional arguments.
 
 - `charm`: A reference to the parent (Loki) charm.
@@ -43,12 +43,10 @@ and three optional arguments.
   If provided, this relation name must match a provided relation in metadata.yaml with the
   `loki_push_api` interface.
 
-  Typically `LokiPushApiConsumer` use "logging" as a relation_name and `LogProxyConsumer` use
-  "log_proxy".
+  The default relation name is "logging" for `LokiPushApiConsumer` and "log-proxy" for
+  `LogProxyConsumer`.
 
-  The default value of this arguments is "logging".
-
-  An example of this in a `metadata.yaml` file should have the following section:
+  For example, a provider's `metadata.yaml` file may look as follows:
 
   ```yaml
   provides:
@@ -56,7 +54,7 @@ and three optional arguments.
       interface: loki_push_api
   ```
 
-  For example, a Loki charm may instantiate the `LokiPushApiProvider` in its constructor as
+  Subsequently, a Loki charm may instantiate the `LokiPushApiProvider` in its constructor as
   follows:
 
       from charms.loki_k8s.v0.loki_push_api import LokiPushApiProvider
@@ -69,21 +67,20 @@ and three optional arguments.
           def __init__(self, *args):
               super().__init__(*args)
               ...
-              self._loki_ready()
+              external_url = urlparse(self._external_url)
+              self.loki_provider = LokiPushApiProvider(
+                  self,
+                  address=external_url.hostname or self.hostname,
+                  port=external_url.port or 80,
+                  scheme=external_url.scheme,
+                  path=f"{external_url.path}/loki/api/v1/push",
+              )
               ...
 
-          def _loki_ready(self):
-              try:
-                  version = self._loki_server.version
-                  self.loki_provider = LokiPushApiProvider(self)
-                  logger.debug("Loki Provider is available. Loki version: %s", version)
-              except LokiServerNotReadyError as e:
-                  self.unit.status = MaintenanceStatus(str(e))
-              except LokiServerError as e:
-                  self.unit.status = BlockedStatus(str(e))
-
-  - `port`: Loki Push Api endpoint port. Default value: 3100.
-  - `rules_dir`: Directory to store alert rules. Default value: "/loki/rules".
+  - `port`: Loki Push Api endpoint port. Default value: `3100`.
+  - `scheme`: Loki Push Api endpoint scheme (`HTTP` or `HTTPS`). Default value: `HTTP`
+  - `address`: Loki Push Api endpoint address. Default value: `localhost`
+  - `path`: Loki Push Api endpoint path. Default value: `loki/api/v1/push`
 
 
 The `LokiPushApiProvider` object has several responsibilities:
@@ -92,7 +89,7 @@ The `LokiPushApiProvider` object has several responsibilities:
    must be unique to all instances (e.g. using a load balancer).
 
 2. Set the Promtail binary URL (`promtail_binary_zip_url`) so clients that use
-   `LogProxyConsumer` object can downloaded and configure it.
+   `LogProxyConsumer` object could download and configure it.
 
 3. Process the metadata of the consumer application, provided via the
    "metadata" field of the consumer data bag, which are used to annotate the
@@ -222,14 +219,14 @@ to do this with promtail.
 
 ## LogProxyConsumer Library Usage
 
-Let's say that we have a workload charm that produces logs and we need to send those logs to a
+Let's say that we have a workload charm that produces logs, and we need to send those logs to a
 workload implementing the `loki_push_api` interface, such as `Loki` or `Grafana Agent`.
 
 Adopting this object in a Charmed Operator consist of two steps:
 
-1. Use the `LogProxyConsumer` class by instanting it in the `__init__` method of the charmed
-   operator. There are two ways to get logs in to promtail. You can give it a list of files to read
-   or you can write to it using the syslog protocol.
+1. Use the `LogProxyConsumer` class by instantiating it in the `__init__` method of the charmed
+   operator. There are two ways to get logs in to promtail. You can give it a list of files to
+   read, or you can write to it using the syslog protocol.
 
    For example:
 
@@ -396,7 +393,7 @@ provider charm generates alerts only for that same charm.
 
 The Loki charm may be related to multiple Loki client charms. Without this, filter
 rules submitted by one provider charm will also result in corresponding alerts for other
-provider charms. Hence every alert rule expression must include such a topology filter stub.
+provider charms. Hence, every alert rule expression must include such a topology filter stub.
 
 Gathering alert rules and generating rule files within the Loki charm is easily done using
 the `alerts()` method of `LokiPushApiProvider`. Alerts generated by Loki will automatically
@@ -483,7 +480,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 18
+LIBPATCH = 21
 
 logger = logging.getLogger(__name__)
 
@@ -1077,6 +1074,10 @@ class LokiPushApiProvider(Object):
                 It is strongly advised not to change the default, so that people
                 deploying your charm will have a consistent experience with all
                 other charms that consume metrics endpoints.
+            port: an optional port of the Loki service (default is "3100").
+            scheme: an optional scheme of the Loki API URL (default is "http").
+            address: an optional address of the Loki service (default is "localhost").
+            path: an optional path of the Loki API URL (default is "loki/api/v1/push")
 
         Raises:
             RelationNotFoundError: If there is no relation in the charm's metadata.yaml
@@ -1186,7 +1187,7 @@ class LokiPushApiProvider(Object):
         """Determine whether alert rules should be regenerated.
 
         If there are alert rules in the relation data bag, tell the charm
-        whether or not to regenerate them based on the boolean returned here.
+        whether to regenerate them based on the boolean returned here.
         """
         if relation.data.get(relation.app).get("alert_rules", None) is not None:
             return True
@@ -1207,7 +1208,7 @@ class LokiPushApiProvider(Object):
             relation: the `Relation` instance to update.
 
         Returns:
-            A boolean indicating whether an event should be emitted so we
+            A boolean indicating whether an event should be emitted, so we
             only emit one on lifecycle events
         """
         relation.data[self._charm.unit]["public_address"] = socket.getfqdn() or ""
@@ -1232,7 +1233,7 @@ class LokiPushApiProvider(Object):
 
         This method should be used when the charm relying on this library needs
         to update the relation data in response to something occurring outside
-        of the `logging` relation lifecycle, e.g., in case of a
+        the `logging` relation lifecycle, e.g., in case of a
         host address change because the charmed operator becomes connected to an
         Ingress after the `logging` relation is established.
 
@@ -1286,7 +1287,7 @@ class LokiPushApiProvider(Object):
         separate alert rules file for each relation since the returned list
         of alert groups are indexed by relation ID. Also for each relation ID
         associated scrape metadata such as Juju model, UUID and application
-        name are provided so the a unique name may be generated for the rules
+        name are provided so a unique name may be generated for the rules
         file. For each relation the structure of data returned is a dictionary
         with four keys
 
@@ -1528,24 +1529,27 @@ class LokiPushApiConsumer(ConsumerBase):
     ):
         """Construct a Loki charm client.
 
-        The `LokiPushApiConsumer` object provides configurations to a Loki client charm.
-        A charm instantiating this object needs Loki information, for instance the
-        Loki API endpoint to push logs.
-        The `LokiPushApiConsumer` can be instantiated as follows:
+        The `LokiPushApiConsumer` object provides configurations to a Loki client charm, such as
+        the Loki API endpoint to push logs. It is intended for workloads that can speak
+        loki_push_api (https://grafana.com/docs/loki/latest/api/#push-log-entries-to-loki), such
+        as grafana-agent.
+        (If you only need to forward a few workload log files, then use LogProxyConsumer.)
+
+        `LokiPushApiConsumer` can be instantiated as follows:
 
             self._loki_consumer = LokiPushApiConsumer(self)
 
         Args:
             charm: a `CharmBase` object that manages this `LokiPushApiConsumer` object.
-                Typically this is `self` in the instantiating class.
+                Typically, this is `self` in the instantiating class.
             relation_name: the string name of the relation interface to look up.
                 If `charm` has exactly one relation with this interface, the relation's
                 name is returned. If none or multiple relations with the provided interface
-                are found, this method will raise either an exception of type
-                NoRelationWithInterfaceFoundError or MultipleRelationsWithInterfaceFoundError,
-                respectively.
+                are found, this method will raise either a NoRelationWithInterfaceFoundError or
+                MultipleRelationsWithInterfaceFoundError exception, respectively.
             alert_rules_path: a string indicating a path where alert rules can be found
-            recursive: Whether or not to scan for rule files recursively.
+            recursive: Whether to scan for rule files recursively.
+            skip_alert_topology_labeling: whether to skip the alert topology labeling.
 
         Raises:
             RelationNotFoundError: If there is no relation in the charm's metadata.yaml
@@ -1732,9 +1736,8 @@ class LogProxyConsumer(ConsumerBase):
         relation_name: the string name of the relation interface to look up.
             If `charm` has exactly one relation with this interface, the relation's
             name is returned. If none or multiple relations with the provided interface
-            are found, this method will raise either an exception of type
-            NoRelationWithInterfaceFoundError or MultipleRelationsWithInterfaceFoundError,
-            respectively.
+            are found, this method will raise either a NoRelationWithInterfaceFoundError or
+            MultipleRelationsWithInterfaceFoundError exception, respectively.
         enable_syslog: Whether to enable syslog integration.
         syslog_port: The port syslog is attached to.
         alert_rules_path: an optional path for the location of alert rules
@@ -1762,7 +1765,7 @@ class LogProxyConsumer(ConsumerBase):
     def __init__(
         self,
         charm,
-        log_files: Optional[list] = None,
+        log_files: Optional[Union[List[str], str]] = None,
         relation_name: str = DEFAULT_LOG_PROXY_RELATION_NAME,
         enable_syslog: bool = False,
         syslog_port: int = 1514,
@@ -1776,13 +1779,21 @@ class LogProxyConsumer(ConsumerBase):
         self._relation_name = relation_name
         self._container = self._get_container(container_name)
         self._container_name = self._get_container_name(container_name)
-        self._log_files = log_files or []
+
+        if not log_files:
+            log_files = []
+        elif isinstance(log_files, str):
+            log_files = [log_files]
+        elif not isinstance(log_files, list) or not all((isinstance(x, str) for x in log_files)):
+            raise TypeError("The 'log_files' argument must be a list of strings.")
+        self._log_files = log_files
+
         self._syslog_port = syslog_port
         self._is_syslog = enable_syslog
         self.topology = JujuTopology.from_charm(charm)
         self._promtail_resource_name = promtail_resource_name or "promtail-bin"
 
-        # architechure used for promtail binary
+        # architecture used for promtail binary
         arch = platform.processor()
         self._arch = "amd64" if arch == "x86_64" else arch
 
@@ -1981,7 +1992,9 @@ class LogProxyConsumer(ConsumerBase):
             workload_binary_path: path in workload container to which promtail binary is pushed.
         """
         with open(binary_path, "rb") as f:
-            self._container.push(workload_binary_path, f, permissions=0o755, make_dirs=True)
+            self._container.push(
+                workload_binary_path, f, permissions=0o755, encoding=None, make_dirs=True
+            )
             logger.debug("The promtail binary file has been pushed to the workload container.")
 
     @property
@@ -1999,8 +2012,7 @@ class LogProxyConsumer(ConsumerBase):
         except NameError as e:
             if "invalid resource name" in str(e):
                 return False
-            else:
-                raise
+            raise
 
     def _push_promtail_if_attached(self, workload_binary_path: str) -> bool:
         """Checks whether Promtail binary is attached to the charm or not.
@@ -2041,7 +2053,7 @@ class LogProxyConsumer(ConsumerBase):
         return False
 
     def _sha256sums_matches(self, file_path: str, sha256sum: str) -> bool:
-        """Checks whether a file's sha256sum matches or not with an specific sha256sum.
+        """Checks whether a file's sha256sum matches or not with a specific sha256sum.
 
         Args:
             file_path: A string representing the files' patch.
@@ -2049,7 +2061,7 @@ class LogProxyConsumer(ConsumerBase):
 
         Returns:
             a boolean representing whether a file's sha256sum matches or not with
-            an specific sha256sum.
+            a specific sha256sum.
         """
         try:
             with open(file_path, "rb") as f:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ module = [
   "charms.grafana_k8s.v0.grafana_dashboard",
   "charms.loki_k8s.v0.loki_push_api",
   "charms.observability_libs.v0.juju_topology",
+  "cosl.*",
   "ops.*",
   "pylxd.*",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+cosl >= 0.0.7
 ops >= 1.2.0
 git+https://github.com/canonical/pylxd@main#egg=pylxd
 pyopenssl

--- a/src/charm.py
+++ b/src/charm.py
@@ -97,7 +97,7 @@ class LxdCharm(CharmBase):
             lxd_initialized=False,
             lxd_snap_path="",
             ovn_certificates_present=False,
-            reboot_required=False,
+            reboot_required="false",
         )
 
         # XXX: not using the default relation_name="grafana-dashboard" to keep supporting the old
@@ -481,7 +481,7 @@ class LxdCharm(CharmBase):
             return
 
         # If some changes needed a reboot to take effect, enter blocked status
-        if self._stored.reboot_required:
+        if self._stored.reboot_required == "true":
             self.unit_blocked("Machine reboot required")
             return
 
@@ -550,7 +550,7 @@ class LxdCharm(CharmBase):
         # Check if any required reboot was done
         self.system_clear_reboot_required()
 
-        if not self._stored.reboot_required and isinstance(self.unit.status, BlockedStatus):
+        if self._stored.reboot_required == "false" and isinstance(self.unit.status, BlockedStatus):
             self.unit_active("Pending configuration changes were applied during the last reboot")
 
         # Apply pending config changes (those were likely queued up while the unit was
@@ -2512,8 +2512,8 @@ class LxdCharm(CharmBase):
     def system_clear_reboot_required(self) -> None:
         """Clear the reboot_required flag if a reboot occurred."""
         # If the required reboot occurred so let's clear the flag
-        if self._stored.reboot_required and not os.path.exists(REBOOT_REQUIRED_FILE):
-            self._stored.reboot_required = False
+        if self._stored.reboot_required == "true" and not os.path.exists(REBOOT_REQUIRED_FILE):
+            self._stored.reboot_required = "false"
             logger.debug("Required reboot done")
 
     def system_set_reboot_required(self) -> None:
@@ -2521,7 +2521,7 @@ class LxdCharm(CharmBase):
         # Touch a flag file indicating that a reboot is required.
         try:
             open(REBOOT_REQUIRED_FILE, "a").close()
-            self._stored.reboot_required = True
+            self._stored.reboot_required = "true"
         except OSError:
             logger.warning(f"Failed to create: {REBOOT_REQUIRED_FILE}")
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -1413,10 +1413,14 @@ class LxdCharm(CharmBase):
 
         net = binding.network
 
-        if not require_ipv4:
-            return str(net.ingress_address)
+        # ingress_addresses can contains strings (hostnames) while we only want IPs
+        addrs = [a for a in net.ingress_addresses if not isinstance(a, str)]
+        if not addrs:
+            return ""
 
-        addrs = net.ingress_addresses
+        if not require_ipv4:
+            return str(addrs[0])
+
         ipv4_addrs = [a for a in addrs if a.version == 4]
         if ipv4_addrs:
             return str(ipv4_addrs[0])

--- a/src/charm.py
+++ b/src/charm.py
@@ -20,7 +20,7 @@ import pylxd
 import yaml
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
 from charms.loki_k8s.v0.loki_push_api import LokiPushApiConsumer
-from charms.observability_libs.v0.juju_topology import JujuTopology
+from cosl.juju_topology import JujuTopology
 from cryptography import x509
 from ops.charm import (
     ActionEvent,

--- a/src/charm.py
+++ b/src/charm.py
@@ -391,10 +391,10 @@ class LxdCharm(CharmBase):
 
     def _on_action_get_client_token(self, event: ActionEvent) -> None:
         """Return a client certificate add token (to use with: `lxc remote add $rmt $token`)."""
-        name = event.params.get("name")
-        projects = event.params.get("projects")
+        name: str = event.params.get("name", "")
+        projects: str = event.params.get("projects", "")
 
-        token = self.lxd_trust_token(name=name, projects=projects)
+        token: str = self.lxd_trust_token(name=name, projects=projects)
         if token:
             msg = f"Client {name} certificate add token:\n{token}"
             event.set_results({"result": msg})
@@ -422,10 +422,10 @@ class LxdCharm(CharmBase):
         # so those need to be processed even when config_changed() returns nothing
         for listener in ("bgp", "dns", "https", "metrics"):
             # Check if we should listen
-            toggle_key = f"lxd-listen-{listener}"
-            toggle_value = self.config.get(toggle_key)
+            toggle_key: str = f"lxd-listen-{listener}"
+            toggle_value: str = self.config.get(toggle_key, "")
             if toggle_value:
-                space_addr = self.juju_space_get_address(listener)
+                space_addr: str = self.juju_space_get_address(listener)
 
                 # Configure a listener or update it if needed
                 if space_addr and space_addr != self._stored.addresses.get(listener):


### PR DESCRIPTION
For now, we need to keep the deprecated lib because the Loki bits depend on it. I opened https://github.com/canonical/loki-k8s-operator/issues/310 asking for Loki to move to `cosl` too.