### PR TITLE
Charmcraft build speedup

### DIFF
--- a/.github/scripts/charmcraft-tweak.py
+++ b/.github/scripts/charmcraft-tweak.py
@@ -1,0 +1,93 @@
+#!/usr/bin/python3
+
+"""Rewrite a charmcraft.yaml to embed the requirements.txt as charm-binary-python-packages."""
+
+import pathlib
+import sys
+import yaml
+
+
+def rewrite_charmcraft(directory: str, unneeded_build_pkgs: list[str]) -> None:
+    """Rewrite a charmcraft.yaml to embed the requirements.txt as charm-binary-python-packages.
+
+    Make sure the provided directory contains a charmcraft.yaml and a requirements.txt file.
+
+    Example of charmcraft.yaml:
+    type: charm
+      - name: ubuntu
+        channel: "22.04"
+    parts:
+      charm:
+        build-packages:
+          - ca-certificates
+          - cargo
+          - git
+          - libffi-dev
+          - libssl-dev
+          - pkg-config
+          - python3-dev
+          - rustc
+
+    Example of requirements.txt:
+    pyopenssl >= 23.1.1
+    pyyaml
+
+    Example of charmcraft.yaml after running this script:
+    type: charm
+      - name: ubuntu
+        channel: "22.04"
+    parts:
+      charm:
+        build-packages:
+          - ca-certificates
+          - cargo
+          - git
+          - libffi-dev
+          - libssl-dev
+          - pkg-config
+          - python3-dev
+          - rustc
+        charm-binary-python-packages:
+          - pyopenssl >= 23.1.1
+          - pyyaml
+    """
+    charmcraft_yaml = pathlib.Path(directory) / "charmcraft.yaml"
+    requirements_txt = pathlib.Path(directory) / "requirements.txt"
+
+    if not charmcraft_yaml.exists():
+        sys.exit("charmcraft.yaml not found")
+    if not requirements_txt.exists():
+        sys.exit("requirements.txt not found")
+
+    with open(charmcraft_yaml, "r") as f:
+        charmcraft = yaml.safe_load(f)
+
+    with open(requirements_txt, "r") as f:
+        requirements = f.read().splitlines()
+
+    # Ensure properly formatted charmcraft.yaml
+    if "parts" not in charmcraft or "charm" not in charmcraft["parts"]:
+        sys.exit("charmcraft.yaml is missing parts/charm")
+
+    # Remove unneeded build packages
+    build_pkgs = charmcraft["parts"]["charm"].get("build-packages", [])
+    if unneeded_build_pkgs and build_pkgs:
+        charmcraft["parts"]["charm"]["build-packages"] = [pkg for pkg in build_pkgs if pkg not in unneeded_build_pkgs]
+
+    # Add requirements.txt as charm-binary-python-packages
+    if "charm-binary-python-packages" not in charmcraft["parts"]["charm"]:
+        charmcraft["parts"]["charm"]["charm-binary-python-packages"] = []
+    charmcraft["parts"]["charm"]["charm-binary-python-packages"] += requirements
+
+    yaml.dump(charmcraft, open(charmcraft_yaml, "w"), sort_keys=False)
+
+
+if __name__ == "__main__":
+    unneeded_build_pkgs: str = ""
+
+    if len(sys.argv) < 2:
+        sys.exit("Missing path to charm directory")
+    if len(sys.argv) > 2:
+        unneeded_build_pkgs = sys.argv[2]
+
+    rewrite_charmcraft(sys.argv[1], unneeded_build_pkgs.split(","))

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,6 +53,14 @@ jobs:
     - name: Build charms
       run: |
           set -eux
+
+          # Charms are normally built without binary deps but that is slow as pyca/cryptography (rust) takes a long time to build.
+          # Not depending on binaries is a good thing for arches lacking some wheels but in CI, we only care about amd64 which has
+          # all the needed wheels. As such, tweak the charmcraft.yaml to include the requirements as binary packages and skip the
+          # lengthy compilations. The official build happening on Launchpad will use the proper/unmangled charmcraft.yaml files.
+          ./.github/scripts/charmcraft-tweak.py . "cargo,libffi-dev,libssl-dev,pkg-config,python3-dev,rustc"
+          ./.github/scripts/charmcraft-tweak.py examples/https-client/ "cargo,libffi-dev,libssl-dev,pkg-config,python3-dev,rustc"
+
           sudo -g lxd charmcraft pack -v
 
           # ancillary charm for testing purposes

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,27 +1,27 @@
 type: charm
 bases:
-  - name: ubuntu
-    channel: "20.04"
-  - name: ubuntu
-    channel: "22.04"
+- name: ubuntu
+  channel: "20.04"
+- name: ubuntu
+  channel: "22.04"
 
 parts:
   charm:
     build-packages:
-      - ca-certificates
-      - cargo
-      - git
-      - libffi-dev
-      - libssl-dev
-      - pkg-config
-      - python3-dev
-      - rustc
+    - ca-certificates
+    - cargo
+    - git
+    - libffi-dev
+    - libssl-dev
+    - pkg-config
+    - python3-dev
+    - rustc
   grafana-dashboard:
-    plugin: dump
-    source: .
-    override-pull: |
+    build-packages:
+      - wget
+    override-pull: |-
       mkdir -p src/grafana_dashboards
       wget --https-only https://grafana.com/api/dashboards/19131/revisions/latest/download -O src/grafana_dashboards/LXD.json
       sed -i 's/{DS_LXD}/{prometheusds}/g' src/grafana_dashboards/LXD.json
-    build-packages:
-      - wget
+    plugin: dump
+    source: .

--- a/examples/https-client/charmcraft.yaml
+++ b/examples/https-client/charmcraft.yaml
@@ -1,15 +1,15 @@
 type: charm
 bases:
-  - name: ubuntu
-    channel: "22.04"
+- name: ubuntu
+  channel: "22.04"
 
 parts:
   charm:
     build-packages:
-      - cargo
-      - git
-      - libffi-dev
-      - libssl-dev
-      - pkg-config
-      - rustc
+    - cargo
+    - git
+    - libffi-dev
+    - libssl-dev
+    - pkg-config
+    - rustc
     charm-entrypoint: src/https-client.py


### PR DESCRIPTION
The "Build charms" step used to take ~30 minutes and now takes ~6 minutes. The real/official/pristine `charmcraft.yaml` file is going to be used on Launchpad builders so it should only speedup CI testing without affecting what gets published to https://charmhub.io/