### PR TITLE
Revert "Drop snap-config-shiftfs-enable config option"

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -92,6 +92,9 @@ options:
     type: boolean
     description: Use snap-specific OVN configuration
     default: true
+  snap-config-shiftfs-enable:
+    type: string
+    description: Enable shiftfs support
 
   sysctl-tuning:
     type: boolean


### PR DESCRIPTION
This reverts commit 1e7ec1402632568d2851bdf16bbc92ebb26de361.

The LXD charm is still compatible with LXD 4.0+ so support for `shiftfs` is still required even if newer LXD versions (`5.20+`) no longer support it.