### PR TITLE
config: add snap-config-ui-enable to control the LXD UI

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -95,6 +95,10 @@ options:
   snap-config-shiftfs-enable:
     type: string
     description: Enable shiftfs support
+  snap-config-ui-enable:
+    type: boolean
+    description: Enable the experimental web interface
+    default: false
 
   sysctl-tuning:
     type: boolean


### PR DESCRIPTION
@tomponline it seems like the snap store needs to be refreshed as the `ui.enable` key isn't showing on https://snapcraft.io/lxd. I'm assuming that fixing the store will also correct the `snap info lxd` part that's also missing that key. Thanks!