### PR TITLE
bundles: best practice for Vault and OVN

### DIFF
--- a/bundles/lxd-and-ovn.yaml
+++ b/bundles/lxd-and-ovn.yaml
@@ -19,32 +19,29 @@ machines:
     # Compute
     series: focal
 applications:
-  postgresql:
-    charm: postgresql
-    channel: stable
-    num_units: 1
-    to:
-    - lxd:0
   vault:
     charm: vault
-    channel: stable
+    channel: 1.8/stable
+    series: jammy
     num_units: 1
     to:
     - lxd:0
     options:
       auto-generate-root-ca-cert: true
-      # XXX: insecure, only for testing
+      # XXX: insecure, only for testing and only works
+      #      with a single unit of vault
       totally-unsecure-auto-unlock: true
   ovn-central:
     charm: ovn-central
-    channel: stable
+    channel: 22.03/stable
     num_units: 3
     to:
-    - 2
-    - 3
-    - 4
+    - lxd:2
+    - lxd:3
+    - lxd:4
   ovn-dedicated-chassis:
     charm: ovn-dedicated-chassis
+    channel: 22.03/stable
     num_units: 5
     to:
     - 1
@@ -64,8 +61,6 @@ applications:
     - 4
     - 5
 relations:
-- - vault:db
-  - postgresql:db
 - - ovn-central:certificates
   - vault:certificates
 - - ovn-dedicated-chassis:certificates


### PR DESCRIPTION
vault: Deploy in HA configuration.

vault: Drop use of postgresql as the DB backend, using the built in storage engine by default.

vault: use jammy base for 1.8/stable support.

ovn-{central,dedicated-chassis}: use 22.03/stable channel.

ovn-central: Place in LXD containers to avoid conflict with chassis.