### PR TITLE
Build multi-arch charm on amd64 architecture only

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,9 +1,35 @@
 type: charm
 bases:
-- name: ubuntu
-  channel: "20.04"
-- name: ubuntu
-  channel: "22.04"
+- build-on:
+  - name: ubuntu
+    channel: "20.04"
+    architectures:
+    - amd64
+  run-on:
+  - name: ubuntu
+    channel: "20.04"
+    architectures:
+    - s390x
+    - ppc64el
+    - arm64
+    - armhf
+    - amd64
+    - riscv64
+- build-on:
+  - name: ubuntu
+    channel: "22.04"
+    architectures:
+    - amd64
+  run-on:
+  - name: ubuntu
+    channel: "22.04"
+    architectures:
+    - s390x
+    - ppc64el
+    - arm64
+    - armhf
+    - amd64
+    - riscv64
 
 parts:
   charm:


### PR DESCRIPTION
Don't build the LXD charm on `riscv64` architecture based runners since a stable `snapcraft` snap isn't yet available on those systems. 

Instead build the multi-arch charm for both `20.04` and `22.04` on `amd64` runners. The same approach was taken by the [Keystone charm](https://git.launchpad.net/charm-keystone/tree/charmcraft.yaml) and is explained here https://discourse.charmhub.io/t/charmcraft-bases-provider-support/4713.

This also allows us to enable `riscv64` support.