### PR TITLE
github: don't prompt for confirmation when removing an app

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,6 +50,8 @@ jobs:
           sudo snap install charmcraft --classic
           sudo snap install juju
 
+          snap list --all
+
     - name: Build charms
       run: |
           set -eux

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -137,7 +137,7 @@ jobs:
 
           # removing the https-client application will break the
           # relation causing the removal of the cert
-          juju remove-application https-client
+          juju remove-application --no-prompt https-client
           juju_wait
           ! juju exec --unit lxd/leader -- lxc config trust list --format csv | grep -E ",juju-relation-https-client/[0-9]+," || false
           juju status --relations
@@ -188,7 +188,7 @@ jobs:
     - name: Cleanup standalone lxd units
       run: |
           set -eux
-          juju remove-application --force lxd
+          juju remove-application --no-prompt --force lxd
           sleep 10
           juju status
 


### PR DESCRIPTION
Juju 3.3 changed `remove-application` to be prompting. Our CI installs whatever Juju version is the `latest/stable` and during the tests for the last PR (#139), it was `3.1/stable` but once merged into `main` it had moved to `3.3/stable`, causing a failure.