### PR TITLE
Default snap-channel to auto to use lxd-installer

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,10 +65,10 @@ jobs:
 
           sudo -g lxd charmcraft pack -v
 
-          # ancillary charm for testing purposes
+          echo "==> ancillary charm for testing purposes"
           sudo -g lxd charmcraft pack -v --project-dir examples/https-client
 
-          # cleanup project to reclaim space
+          echo "==> cleanup project to reclaim space"
           sudo -g lxd lxc list --project charmcraft -c n -f csv | xargs --no-run-if-empty sudo -g lxd lxc delete --project charmcraft
 
     - name: Upload charms
@@ -109,7 +109,7 @@ jobs:
           juju add-model ci-testing
           juju model-config logging-config="<root>=WARNING;unit=DEBUG"
 
-          # Test 20.04 charm in standalone mode
+          echo "==> Test 20.04 charm in standalone mode"
           juju deploy ./lxd_ubuntu-20.04-amd64.charm --num-units 1 --config lxd-listen-https=true
           juju deploy ./https-client_ubuntu-22.04-amd64.charm
           juju relate https-client lxd
@@ -117,28 +117,30 @@ jobs:
 
           juju status --relations
 
-          # confirm lxd now trusts the client cert
+          echo "==> list trusted client certs"
+          juju exec --unit lxd/leader -- lxc config trust list --format csv
+
+          echo "==> confirm lxd now trusts the client cert"
           juju exec --unit lxd/leader -- lxc config trust list --format csv | grep -E ",juju-relation-https-client/[0-9]+,"
 
-          # break the relationship to have the client cert removed
+          echo "==> break the relationship to have the client cert removed"
           juju remove-relation https-client lxd
           juju_wait
 
-          # check that the client cert was not left behind
+          echo "==> check that the client cert was not left behind"
           ! juju exec --unit lxd/leader -- lxc config trust list --format csv | grep -E ",juju-relation-https-client/[0-9]+," || false
 
-          # set the projects config and re-establish the relation
+          echo "==> set the projects config and re-establish the relation"
           juju config https-client projects="default"
           juju relate https-client lxd
           juju_wait
 
-          # check that the client cert is now restricted
+          echo "==> check that the client cert is now restricted"
           FINGERPRINT="$(juju exec --unit lxd/leader -- lxc config trust list --format csv | awk -F, '/,juju-relation-https-client/ {print $4}')"
           juju exec --unit lxd/leader -- lxc config trust show "$FINGERPRINT"
           juju exec --unit lxd/leader -- lxc config trust show "$FINGERPRINT" | grep -xF 'restricted: true'
 
-          # removing the https-client application will break the
-          # relation causing the removal of the cert
+          echo "==> removing the https-client application will break the relation causing the removal of the cert"
           juju remove-application --no-prompt https-client
           juju_wait
           ! juju exec --unit lxd/leader -- lxc config trust list --format csv | grep -E ",juju-relation-https-client/[0-9]+," || false
@@ -147,24 +149,25 @@ jobs:
     - name: Test opening/closing ports
       run: |
           set -eux
-          # open the dns, bgp and metrics ports
+          echo "==> open the dns, bgp and metrics ports"
           juju config lxd lxd-listen-dns=true lxd-listen-bgp=true lxd-listen-metrics=true
           juju wait-for application lxd --query='status=="active"'
           juju status
-          # check that the dns, bgp, https and metrics ports are opened
+          echo "==> check that the dns, bgp, https and metrics ports are opened"
           OPENED_PORTS="$(juju exec --unit lxd/leader "opened-ports" | grep -cE '^(53|179|8443|9100)/tcp$')"
           [ "$OPENED_PORTS" -eq 4 ]
-          # close the dns, bgp and metrics ports
+          echo "==> close the dns, bgp and metrics ports"
           juju config lxd lxd-listen-dns=false lxd-listen-bgp=false lxd-listen-metrics=false
           juju wait-for application lxd --query='status=="active"'
           juju status
-          # check that only the https port remains opened
+          echo "==> check that only the https port remains opened"
           HTTPS_PORT="$(juju exec --unit lxd/leader "opened-ports" | grep -E '^[0-9]+/tcp$')"
           [ "$HTTPS_PORT" = "8443/tcp" ]
 
     - name: Scale the number of lxd units
       run: |
           set -eux
+          echo "==> Add a LXD unit"
           juju add-unit lxd
           juju wait-for application lxd --query='status=="active"'
           juju status
@@ -174,17 +177,19 @@ jobs:
           set -eux
           CERT_NAME="trusted-client-$$"
 
-          # Generate local cert/key
+          echo "==> Generate local cert/key"
           rm -rf ~/snap/lxd/common/config/
           lxc remote add localhost --accept-certificate --password=abc 2>/dev/null || true
 
+          echo "==> Add trusted client cert"
           juju run --wait=2m lxd/leader add-trusted-client name="$CERT_NAME" cert="$(cat ~/snap/lxd/common/config/client.crt)" | grep -F 'result: The client certificate is now trusted'
 
-          # Confirm the user's cert was added to the trusted list
+          echo "==> Confirm the user's cert was added to the trusted list"
           juju exec --unit lxd/leader -- lxc config trust list -f csv | grep "^client,${CERT_NAME},"
 
+          echo "==> Remove trusted client cert"
           juju run --wait=2m lxd/leader remove-trusted-client fingerprint="$(openssl x509 -noout -fingerprint -sha256 -in ~/snap/lxd/common/config/client.crt)" | grep -F 'result: The client certificate is no longer trusted'
-          # Confirm the user's cert was removed from the trusted list
+          echo "==> Confirm the user's cert was removed from the trusted list"
           ! juju exec --unit lxd/leader -- lxc config trust list -f csv | grep "^client,${CERT_NAME}," || false
 
     - name: Cleanup standalone lxd units
@@ -211,12 +216,13 @@ jobs:
           }
           trap debug err exit
 
-          # Test 22.04 charm in cluster mode
+          echo "==> Test 22.04 charm in cluster mode"
           NODE_CREATED="3"
           juju deploy ./lxd_ubuntu-22.04-amd64.charm --num-units "$NODE_CREATED" --config mode=cluster --config lxd-listen-https=true
           juju wait-for application lxd --query='life=="alive" && status=="available" && forEach(units, unit => unit.life=="alive")' || true  # wait for leader-election
           juju status --relations
 
+          echo "==> Check that all members are online and fully operational"
           NODE_JOINED="$(juju exec --unit lxd/leader -- lxc cluster list --format csv | grep -cF ',ONLINE,Fully operational')"
           [ "$NODE_JOINED" -eq "$NODE_CREATED" ]
 
@@ -226,13 +232,14 @@ jobs:
           CERT_NAME="get-client-token-$$"
           REMOTE_NAME="rmt-$$"
 
+          echo "==> Obtain a client-token"
           token="$(juju run --wait=2m lxd/leader get-client-token name="$CERT_NAME" | sed -n '/^\s\+Client [^ ]\+ certificate add token:$/,+1 p' | sed '/^\s\+Client /d; s/^\s\+//')"
           lxc remote add "$REMOTE_NAME" "$token"
 
-          # Test the newly added remote
+          echo "==> Test the newly added remote"
           lxc config show "$REMOTE_NAME":
 
-          # Confirm the user's cert was added to the trusted list
+          echo "==> Confirm the user's cert was added to the trusted list"
           juju exec --unit lxd/leader -- lxc config trust list -f csv | grep "^client,${CERT_NAME},"
 
     - name: Check for errors

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,7 +110,7 @@ jobs:
           juju model-config logging-config="<root>=WARNING;unit=DEBUG"
 
           echo "==> Test 20.04 charm in standalone mode"
-          juju deploy ./lxd_ubuntu-20.04-amd64.charm --num-units 1 --config lxd-listen-https=true
+          juju deploy ./lxd_ubuntu-20.04-amd64.charm --num-units 1 --config lxd-listen-https=true --config snap-channel="5.0/stable"
           juju deploy ./https-client_ubuntu-22.04-amd64.charm
           juju relate https-client lxd
           juju_wait

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Follow `Juju`'s [Charmed Operator Lifecycle Manager](https://juju.is/docs/olm) t
 juju deploy ch:lxd
 ```
 
-Or for a set of 4 units using the `4.0/stable` snap with the HTTPS listener enabled:
+Or for a set of 4 units using the `5.0/stable` snap with the HTTPS listener enabled:
 
 ```shell
-juju deploy ch:lxd --num-units 4 --config snap-channel="4.0/stable" --config lxd-listen-https=true
+juju deploy ch:lxd --num-units 4 --config snap-channel="5.0/stable" --config lxd-listen-https=true
 ```
 
 Or a unit using local storage as `ZFS` storage backend:

--- a/README.md
+++ b/README.md
@@ -90,9 +90,13 @@ In general, if something is doable by the LXD API, the charm won't replicate the
 
 ## Supported LXD versions
 
-The charm only supports currently supported versions of LXD, including both long term support and feature releases.
+The charm only supports currently supported versions of LXD, including both long term support and feature releases. Please see the known issues section below.
 
 ## Known issues
+
+### LXD 4.0 does not support the `https` relation
+
+With LXD 4.0, `lxc config trust list --format csv` does not show the certificate name provided when adding the certificate. This prevents the charm from adding the `juju-relation-` prefix that is required to later remove the certificate when the relation is broken. Because of this, the charm will refuse to add the certificate if the LXD is too old to allow proper trust management.
 
 ### Cluster leader removal
 

--- a/config.yaml
+++ b/config.yaml
@@ -45,8 +45,8 @@ options:
 
   snap-channel:
     type: string
-    default: "latest/stable"
-    description: The snap store channel for LXD to use
+    default: "auto"
+    description: The snap store channel for LXD to use or `auto` to use `lxd-installer` if available with a fallback to the default channel
 
   snap-config-ceph-builtin:
     type: boolean

--- a/examples/https-client/src/https-client.py
+++ b/examples/https-client/src/https-client.py
@@ -66,7 +66,7 @@ class HttpsClientCharm(CharmBase):
         try:
             subprocess.run(cmd, capture_output=True, check=True)
         except subprocess.CalledProcessError as e:
-            self.unit_blocked(f'Failed to run "{e.cmd}": {e.stderr} ({e.returncode})')
+            self.unit_blocked(f"Failed to run {e.cmd!r}: {e.stderr} ({e.returncode})")
             return
 
     @property

--- a/src/charm.py
+++ b/src/charm.py
@@ -129,7 +129,8 @@ class LxdCharm(CharmBase):
         # Relation event handlers
         self.framework.observe(self.on.ceph_relation_changed, self._on_ceph_relation_changed)
         self.framework.observe(
-            self.on.certificates_relation_changed, self._on_certificates_relation_changed
+            self.on.certificates_relation_changed,
+            self._on_certificates_relation_changed,
         )
         self.framework.observe(self.on.cluster_relation_changed, self._on_cluster_relation_changed)
         self.framework.observe(self.on.cluster_relation_created, self._on_cluster_relation_created)
@@ -137,7 +138,8 @@ class LxdCharm(CharmBase):
             self.on.cluster_relation_departed, self._on_cluster_relation_departed
         )
         self.framework.observe(
-            self.on.grafana_dashboard_relation_changed, self._on_grafana_dashboard_relation_changed
+            self.on.grafana_dashboard_relation_changed,
+            self._on_grafana_dashboard_relation_changed,
         )
         self.framework.observe(self.on.https_relation_broken, self._on_https_relation_broken)
         self.framework.observe(self.on.https_relation_changed, self._on_https_relation_changed)
@@ -154,20 +156,24 @@ class LxdCharm(CharmBase):
             self.on.ovsdb_cms_relation_changed, self._on_ovsdb_cms_relation_changed
         )
         self.framework.observe(
-            self.on.prometheus_manual_relation_changed, self._on_prometheus_manual_relation_changed
+            self.on.prometheus_manual_relation_changed,
+            self._on_prometheus_manual_relation_changed,
         )
         self.framework.observe(
             self.on.prometheus_manual_relation_departed,
             self._on_prometheus_manual_relation_departed,
         )
         self.framework.observe(
-            self.on.metrics_endpoint_relation_changed, self._on_metrics_endpoint_relation_changed
+            self.on.metrics_endpoint_relation_changed,
+            self._on_metrics_endpoint_relation_changed,
         )
         self.framework.observe(
-            self.on.metrics_endpoint_relation_created, self._on_metrics_endpoint_relation_created
+            self.on.metrics_endpoint_relation_created,
+            self._on_metrics_endpoint_relation_created,
         )
         self.framework.observe(
-            self.on.metrics_endpoint_relation_departed, self._on_metrics_endpoint_relation_departed
+            self.on.metrics_endpoint_relation_departed,
+            self._on_metrics_endpoint_relation_departed,
         )
 
     @property
@@ -621,7 +627,7 @@ class LxdCharm(CharmBase):
 
             if k.startswith("lxd-"):
                 logger.warning(
-                    f"The new {k!r} key won\'t be applied to existing units "
+                    f"The new {k!r} key won't be applied to existing units "
                     "as their LXD is already initialized"
                 )
                 self._stored.config[k] = v
@@ -1576,7 +1582,10 @@ class LxdCharm(CharmBase):
                 f.write("\n".join(SYSTEMD_TMPFILES_CONFIGS) + "\n")
             try:
                 subprocess.run(
-                    ["systemd-tmpfiles", "--create"], capture_output=True, check=True, timeout=600
+                    ["systemd-tmpfiles", "--create"],
+                    capture_output=True,
+                    check=True,
+                    timeout=600,
                 )
             except subprocess.CalledProcessError as e:
                 if not self._stored.inside_container:
@@ -1660,7 +1669,10 @@ class LxdCharm(CharmBase):
         self.unit_maintenance("Joining cluster")
         try:
             subprocess.run(
-                ["lxd", "init", "--preseed"], check=True, input=preseed_yaml, timeout=600
+                ["lxd", "init", "--preseed"],
+                check=True,
+                input=preseed_yaml,
+                timeout=600,
             )
         except subprocess.CalledProcessError as e:
             self.unit_blocked(f"Failed to run {e.cmd!r}: {e.stderr} ({e.returncode})")
@@ -2157,7 +2169,9 @@ class LxdCharm(CharmBase):
             )
             mon.start()
             subprocess.run(
-                ["systemctl", "reload", "snap.lxd.daemon.service"], capture_output=True, check=True
+                ["systemctl", "reload", "snap.lxd.daemon.service"],
+                capture_output=True,
+                check=True,
             )
             mon.join(timeout=600.0)
 
@@ -2490,7 +2504,10 @@ class LxdCharm(CharmBase):
             )
             if os.path.exists("/var/lib/lxd"):
                 subprocess.run(
-                    ["lxd.migrate", "-yes"], capture_output=True, check=True, timeout=600
+                    ["lxd.migrate", "-yes"],
+                    capture_output=True,
+                    check=True,
+                    timeout=600,
                 )
         except subprocess.CalledProcessError as e:
             self.unit_blocked(f"Failed to run {e.cmd!r}: {e.stderr} ({e.returncode})")

--- a/src/charm.py
+++ b/src/charm.py
@@ -379,12 +379,12 @@ class LxdCharm(CharmBase):
         try:
             b = subprocess.run(["lxd.buginfo"], capture_output=True, check=True, timeout=600)
         except subprocess.CalledProcessError as e:
-            msg = f'Failed to run "{e.cmd}": {e.stderr} ({e.returncode})'
+            msg = f"Failed to run {e.cmd!r}: {e.stderr} ({e.returncode})"
             event.fail(msg)
             logger.error(msg)
             raise RuntimeError
         except subprocess.TimeoutExpired as e:
-            msg = f'Timeout exceeded while running "{e.cmd}"'
+            msg = f"Timeout exceeded while running {e.cmd!r}"
             event.fail(msg)
             logger.error(msg)
             raise RuntimeError
@@ -621,7 +621,7 @@ class LxdCharm(CharmBase):
 
             if k.startswith("lxd-"):
                 logger.warning(
-                    f'The new "{k}" key won\'t be applied to existing units '
+                    f"The new {k!r} key won\'t be applied to existing units "
                     "as their LXD is already initialized"
                 )
                 self._stored.config[k] = v
@@ -1546,14 +1546,14 @@ class LxdCharm(CharmBase):
                 )
             except subprocess.CalledProcessError as e:
                 if not self._stored.inside_container:
-                    self.unit_blocked(f'Failed to run "{e.cmd}": {e.stderr} ({e.returncode})')
+                    self.unit_blocked(f"Failed to run {e.cmd!r}: {e.stderr} ({e.returncode})")
                     raise RuntimeError
                 else:
                     self.unit_maintenance(
-                        f'Ignoring failed execution of "{e.cmd}" due to being inside a container'
+                        f"Ignoring failed execution of {e.cmd!r} due to being inside a container"
                     )
             except subprocess.TimeoutExpired as e:
-                self.unit_blocked(f'Timeout exceeded while running "{e.cmd}"')
+                self.unit_blocked(f"Timeout exceeded while running {e.cmd!r}")
                 raise RuntimeError
 
         elif os.path.exists(sysctl_file):
@@ -1580,14 +1580,14 @@ class LxdCharm(CharmBase):
                 )
             except subprocess.CalledProcessError as e:
                 if not self._stored.inside_container:
-                    self.unit_blocked(f'Failed to run "{e.cmd}": {e.stderr} ({e.returncode})')
+                    self.unit_blocked(f"Failed to run {e.cmd!r}: {e.stderr} ({e.returncode})")
                     raise RuntimeError
                 else:
                     self.unit_maintenance(
-                        f'Ignoring failed execution of "{e.cmd}" due to being inside a container'
+                        f"Ignoring failed execution of {e.cmd!r} due to being inside a container"
                     )
             except subprocess.TimeoutExpired as e:
-                self.unit_blocked(f'Timeout exceeded while running "{e.cmd}"')
+                self.unit_blocked(f"Timeout exceeded while running {e.cmd!r}")
                 raise RuntimeError
 
         elif os.path.exists(systemd_tmpfiles):
@@ -1663,7 +1663,7 @@ class LxdCharm(CharmBase):
                 ["lxd", "init", "--preseed"], check=True, input=preseed_yaml, timeout=600
             )
         except subprocess.CalledProcessError as e:
-            self.unit_blocked(f'Failed to run "{e.cmd}": {e.stderr} ({e.returncode})')
+            self.unit_blocked(f"Failed to run {e.cmd!r}: {e.stderr} ({e.returncode})")
 
             # Leave a copy of the YAML preseed that didn't work
             handle, tmp_file = tempfile.mkstemp()
@@ -1672,7 +1672,7 @@ class LxdCharm(CharmBase):
             logger.error(f"The YAML preseed that caused a failure was saved to {tmp_file}")
             raise RuntimeError
         except subprocess.TimeoutExpired as e:
-            logger.error(f'Timeout exceeded while running "{e.cmd}"')
+            logger.error(f"Timeout exceeded while running {e.cmd!r}")
             raise RuntimeError
 
         self.unit_active()
@@ -1740,10 +1740,10 @@ class LxdCharm(CharmBase):
                 timeout=600,
             )
         except subprocess.CalledProcessError as e:
-            logger.error(f'Failed to run "{e.cmd}": {e.stderr} ({e.returncode})')
+            logger.error(f"Failed to run {e.cmd!r}: {e.stderr} ({e.returncode})")
             return ("", "")
         except subprocess.TimeoutExpired as e:
-            logger.error(f'Timeout exceeded while running "{e.cmd}"')
+            logger.error(f"Timeout exceeded while running {e.cmd!r}")
             return ("", "")
 
         # The key data was output to stdout and never touched the disk
@@ -1983,10 +1983,10 @@ class LxdCharm(CharmBase):
                     timeout=600,
                 )
             except subprocess.CalledProcessError as e:
-                self.unit_blocked(f'Failed to run "{e.cmd}": {e.stderr} ({e.returncode})')
+                self.unit_blocked(f"Failed to run {e.cmd!r}: {e.stderr} ({e.returncode})")
                 raise RuntimeError
             except subprocess.TimeoutExpired as e:
-                self.unit_blocked(f'Timeout exceeded while running "{e.cmd}"')
+                self.unit_blocked(f"Timeout exceeded while running {e.cmd!r}")
                 raise RuntimeError
         else:
             self.unit_maintenance("Performing initial configuration")
@@ -2169,7 +2169,7 @@ class LxdCharm(CharmBase):
                 raise RuntimeError
 
         except subprocess.CalledProcessError as e:
-            self.unit_blocked(f'Failed to run "{e.cmd}": {e.stderr} ({e.returncode})')
+            self.unit_blocked(f"Failed to run {e.cmd!r}: {e.stderr} ({e.returncode})")
             raise RuntimeError
 
     def lxd_set_address(self, listener: str, addr: str) -> bool:
@@ -2226,10 +2226,10 @@ class LxdCharm(CharmBase):
                 timeout=600,
             )
         except subprocess.CalledProcessError as e:
-            logger.error(f'Failed to run "{e.cmd}": {e.stderr} ({e.returncode})')
+            logger.error(f"Failed to run {e.cmd!r}: {e.stderr} ({e.returncode})")
             return False
         except subprocess.TimeoutExpired as e:
-            logger.error(f'Timeout exceeded while running "{e.cmd}"')
+            logger.error(f"Timeout exceeded while running {e.cmd!r}")
             return False
 
         # Save the addr instead of the socket because it makes it easier
@@ -2436,10 +2436,10 @@ class LxdCharm(CharmBase):
                 timeout=600,
             )
         except subprocess.CalledProcessError as e:
-            self.unit_blocked(f'Failed to run "{e.cmd}": {e.stderr} ({e.returncode})')
+            self.unit_blocked(f"Failed to run {e.cmd!r}: {e.stderr} ({e.returncode})")
             raise RuntimeError
         except subprocess.TimeoutExpired as e:
-            self.unit_blocked(f'Timeout exceeded while running "{e.cmd}"')
+            self.unit_blocked(f"Timeout exceeded while running {e.cmd!r}")
             raise RuntimeError
 
         # If "snap set lxd" was successful: save all the k/v applied
@@ -2493,10 +2493,10 @@ class LxdCharm(CharmBase):
                     ["lxd.migrate", "-yes"], capture_output=True, check=True, timeout=600
                 )
         except subprocess.CalledProcessError as e:
-            self.unit_blocked(f'Failed to run "{e.cmd}": {e.stderr} ({e.returncode})')
+            self.unit_blocked(f"Failed to run {e.cmd!r}: {e.stderr} ({e.returncode})")
             raise RuntimeError
         except subprocess.TimeoutExpired as e:
-            self.unit_blocked(f'Timeout exceeded while running "{e.cmd}"')
+            self.unit_blocked(f"Timeout exceeded while running {e.cmd!r}")
             raise RuntimeError
 
         # Done with the snap installation
@@ -2530,10 +2530,10 @@ class LxdCharm(CharmBase):
             if enable:
                 subprocess.run(enable, capture_output=True, check=True, timeout=600)
         except subprocess.CalledProcessError as e:
-            self.unit_blocked(f'Failed to run "{e.cmd}": {e.stderr} ({e.returncode})')
+            self.unit_blocked(f"Failed to run {e.cmd!r}: {e.stderr} ({e.returncode})")
             raise RuntimeError
         except subprocess.TimeoutExpired as e:
-            self.unit_blocked(f'Timeout exceeded while running "{e.cmd}"')
+            self.unit_blocked(f"Timeout exceeded while running {e.cmd!r}")
             raise RuntimeError
 
     def snap_sideload_lxd_binary(self) -> None:


### PR DESCRIPTION
This PR unearthed a bug with LXD 4.0 (which is now installed on 20.04 hosts, unless `snap-channel` is overridden). This bug is now avoided by refusing to accept client cert via the `https` relation when LXD 4.0 is used as otherwise we cannot deal with the cert removal when the relation is broken.

LXD 5.0+ is not affected which is why this was not visible before as in the Ubuntu 20.04 case, we end up keeping the LXD 4.0 snap that comes with the distro.