### PR TITLE
examples/https-client: Update README

### DIFF
--- a/examples/https-client/README.md
+++ b/examples/https-client/README.md
@@ -7,4 +7,4 @@ juju deploy ./https-client_ubuntu-20.04-amd64.charm
 juju relate https-client lxd
 ```
 
-Note: the `https-client_ubuntu-20.04-amd64.charm` can be built locally with `charmcraft build` or downloaded from GitHub tests artifacts.
+Note: the `https-client_ubuntu-20.04-amd64.charm` can be built locally with `charmcraft pack` or downloaded from GitHub tests artifacts.


### PR DESCRIPTION
Whilst preparing the charm release from `edge` to `stable` I was playing with the changes introduced in https://github.com/canonical/charm-lxd/pull/151 and saw the command isn't up to date. 

I guess the command was changed from `build` to `pack`? 