### PR TITLE
Drop 20.04 base

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -118,8 +118,8 @@ jobs:
           juju add-model ci-testing
           juju model-config logging-config="<root>=WARNING;unit=DEBUG"
 
-          echo "==> Test 20.04 charm in standalone mode"
-          juju deploy ./lxd_ubuntu-20.04-amd64.charm --num-units 1 --config lxd-listen-https=true --config snap-channel="5.0/stable"
+          echo "==> Test 22.04 charm in standalone mode"
+          juju deploy ./lxd_ubuntu-22.04-amd64.charm --num-units 1 --config lxd-listen-https=true --config snap-channel="5.0/stable"
           juju deploy ./https-client_ubuntu-22.04-amd64.charm
           juju relate https-client lxd
           juju_wait

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,8 +1,6 @@
 type: charm
 bases:
 - name: ubuntu
-  channel: "20.04"
-- name: ubuntu
   channel: "22.04"
 
 parts:

--- a/examples/https-client/README.md
+++ b/examples/https-client/README.md
@@ -3,8 +3,8 @@
 This simple example charm is used to establish a relation with the LXD charm:
 
 ```shell
-juju deploy ./https-client_ubuntu-20.04-amd64.charm
+juju deploy ./https-client_ubuntu-22.04-amd64.charm
 juju relate https-client lxd
 ```
 
-Note: the `https-client_ubuntu-20.04-amd64.charm` can be built locally with `charmcraft pack` or downloaded from GitHub tests artifacts.
+Note: the `https-client_ubuntu-22.04-amd64.charm` can be built locally with `charmcraft pack` or downloaded from GitHub tests artifacts.


### PR DESCRIPTION
20.04 is out of standard support and while removing this base, we will keep the previous charm revisions for 20.04 available in the store if anyone needs them.